### PR TITLE
Wrap move name families with more than 1 letter with `<>` angle brackets.

### DIFF
--- a/src/PuzzleGeometry.ts
+++ b/src/PuzzleGeometry.ts
@@ -1035,20 +1035,24 @@ export class PuzzleGeometry {
          bits = nbits ;
          inverted++ ;
       }
-      var movename = geo[0] ;
+      var movenameFamily = geo[0];
+      var movenamePrefix = "";
       var hibit = 0 ;
       while (bits >> (1 + hibit))
          hibit++ ;
       if (bits == (1 << hibit)) {
          if (hibit > 0)
-            movename = (hibit + 1) + movename ;
+            movenamePrefix = String(hibit + 1) ;
       } else if (bits == ((2 << hibit) - 1)) {
-         movename = movename.toLowerCase() ;
+         movenameFamily = movenameFamily.toLowerCase() ;
          if (hibit > 1)
-            movename = (hibit + 1) + movename ;
+            movenamePrefix = String(hibit + 1) ;
       } else
          throw "We only support slice and outer block moves right now. " + bits ;
-      return [movename, inverted] ;
+      if (movenameFamily.length > 1) {
+         movenameFamily = `<${movenameFamily}>`
+      }
+      return [movenamePrefix + movenameFamily, inverted] ;
    }
    writeksolve(name:string, fortwisty:boolean):string {
    // write ksolve; mirrored off original q.pl


### PR DESCRIPTION
`alg.js` currently has a runtime `allowLongMoveNames(true)` config option. This
commit updates `getmovename()` to emit all moves in a format that `alg.js` will
accept when that option is enabled.

We may be able to get rid of the angle brackets in the long term, but in the
short term this allows long move names with an alg parser that:

1) is puzzle-agnostic, and
2) allow leaving out whitespace between moves.